### PR TITLE
add AI contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,13 @@ both licenses — see the [CLA](#contributor-license-agreement) below.
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run `ruff check` and `ruff format` before submitting.
 
+## AI-assisted contributions
+
+AI-assisted contributions (e.g. code written with Copilot, Claude, ChatGPT) are
+welcome. However, AI co-author lines (`Co-Authored-By`) are not permitted in
+commit messages — a pre-commit hook enforces this. You are the author of your
+contribution; the tooling you used does not need attribution in the git history.
+
 ---
 
 ## Contributor License Agreement

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Pure-Python HART-IP **client** library. Server functionality is not included.
 
-Supports HART-IP v1 (plaintext, TCP/UDP) and v2 (TLS, Direct PDU, Audit Log).
+Supports HART-IP v1 (plaintext, TCP/UDP) and v2 (TLS, Direct PDU, Audit Log). DTLS is not supported — Python's `ssl` module does not provide DTLS.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Add AI-assisted contributions section to CONTRIBUTING.md after the Code style section
- Documents that AI tools are welcome but Co-Authored-By lines are not permitted in commits

## Test plan
- [x] Verify section appears in correct location in CONTRIBUTING.md
- [x] Pre-commit hooks pass (including the co-author line blocker)